### PR TITLE
Delete Wattometer data after download

### DIFF
--- a/AndroidRunner/Plugins/wattometer/Wattometer.py
+++ b/AndroidRunner/Plugins/wattometer/Wattometer.py
@@ -61,6 +61,13 @@ class Wattometer(Profiler):
                 out_file.write(resp.read())
         except Exception as exc:
             self.logger.warning(f"Wattometer download failed: {exc}")
+            return
+
+        del_url = f"http://{self.ip}/deleteFile?file={filename}"
+        try:
+            request.urlopen(del_url, timeout=5)
+        except Exception as exc:
+            self.logger.warning(f"Wattometer delete failed: {exc}")
 
     def unload(self, device):
         return


### PR DESCRIPTION
## Summary
- delete data file from wattometer after retrieving it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mock')*

------
https://chatgpt.com/codex/tasks/task_e_6881f0554f9c832eac9f607f936af908